### PR TITLE
Add exit tool signal to Signal enum for killing of jobs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nova-common"
-version = "0.2.1"
+version = "0.2.2"
 description = "NOVA Common Project"
 authors = ["Sergey Yakubov yakubovs@ornl.gov"]
 readme = "README.md"

--- a/src/nova/common/signals.py
+++ b/src/nova/common/signals.py
@@ -10,6 +10,7 @@ class Signal(str, Enum):
     OUTPUTS = "outputs"
     TOOL_COMMAND = "tool_command"
     ERROR_MESSAGE = "error_message"
+    EXIT_SIGNAL = "kill_jobs_on_exit"
 
 
 def get_signal_id(id: str, signal: Signal) -> str:


### PR DESCRIPTION
Add a signal to be used by Nova Trame to kill jobs on exit.